### PR TITLE
Add LRU Cache

### DIFF
--- a/add_lru_cache.py
+++ b/add_lru_cache.py
@@ -1,0 +1,26 @@
+class LRUCache:
+
+    def __init__(self, capacity):
+        self.vals = dict()
+        self.max_size = capacity
+
+    def put(self, key, value):
+        if key in self.vals:
+            del self.vals[key]
+            self.vals[key] = value
+        else:
+            if len(self.vals) < self.max_size:
+                self.vals[key] = value
+            else:
+                del self.vals[list(self.vals)[0]]
+                self.vals[key] = value
+
+    def get(self, key):
+        if key in self.vals:
+            return self.vals[key]
+        return None
+
+# Your LRUCache object will be instantiated and called as such:
+# obj = LRUCache(capacity)
+# param_1 = obj.get(key)
+# obj.put(key,value)


### PR DESCRIPTION
Implements the LRUCache class:

`LRUCache(int capacity)` Initializes the LRU cache with positive size capacity.
`int get(int key)` Return the value of the key if the key exists, otherwise return None.
`void put(int key, int value)` Update the value of the key if the key exists. Otherwise, add the key-value pair to the cache. If the number of keys exceeds the capacity from this operation, evict the least recently used key.